### PR TITLE
Fix ExtensionTrayMenu incorrect declaration

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -3890,7 +3890,7 @@ declare namespace overwolf.os.tray {
   function setMenu(menu: ExtensionTrayMenu, callback: CallbackFunction<Result>): void;
 
   interface ExtensionTrayMenu {
-    menu_items: { menu_items: menu_item[] };
+    menu_items: menu_item[];
   }
 
   interface menu_item {


### PR DESCRIPTION
The current `ExtensionTrayMenu` definition look like a typo and triggers an exception when used as is.
I reckon this is the correct definition, feel free to correct me if I'm wrong.