### PR TITLE
Fix type of overwolf.settings.hotkeys.get 

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -5276,7 +5276,7 @@ declare namespace overwolf.settings.hotkeys {
   /**
    * Returns the hotkey assigned for the current extension in all the games.
    */
-  function get(): CallbackFunction<GetAssignedHotkeyResult>;
+  function get(callback: CallbackFunction<GetAssignedHotkeyResult>): void;
 
   /**
    * Fired only for hotkeys that are set in the manifest as hold.


### PR DESCRIPTION
`overwolf.settings.hotkeys.get` expects a callback.
See:
https://overwolf.github.io/docs/api/overwolf-settings-hotkeys#getcallback