### PR TITLE
Created |WindowStateEx| type

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -1044,12 +1044,15 @@ declare namespace overwolf.windows {
       ExclamationMark = "ExclamationMark",
     }
   }
-
+	 
+  type WindowStateEx =
+    "closed" | "minimized" | "hidden" | "normal" | "maximized";
+	  
   interface WindowInfo {
     name: string;
     id: string;
     state: string;
-    stateEx: "closed" | "minimized" | "hidden" | "normal" | "maximized";
+    stateEx: WindowStateEx;
     isVisible: boolean;
     left: number;
     top: number;
@@ -1104,19 +1107,12 @@ declare namespace overwolf.windows {
   interface GetWindowStateResult extends Result {
     window_id?: string;
     window_state?: string;
-    window_state_ex?:
-      | "closed"
-      | "minimized"
-      | "hidden"
-      | "normal"
-      | "maximized";
+    window_state_ex?: WindowStateEx;
   }
 
   interface GetWindowsStatesResult extends Result {
     result: Dictionary<string>;
-    resultV2: Dictionary<
-      "closed" | "minimized" | "hidden" | "normal" | "maximized"
-    >;
+    resultV2: Dictionary<WindowStateEx>;
   }
 
   interface IsMutedResult extends Result {
@@ -1144,8 +1140,8 @@ declare namespace overwolf.windows {
     window_id: string;
     window_state: string;
     window_previous_state: string;
-    window_state_ex: string;
-    window_previous_state_ex: string;
+    window_state_ex: WindowStateEx;
+    window_previous_state_ex: WindowStateEx;
     app_id: string;
     window_name: string;
   }


### PR DESCRIPTION
Replaced strings "closed" | "minimized" | "hidden" | "normal" | "maximized" with new type, and changed |WindowStateChangedEvent.window_state_ex| and |WindowStateChangedEvent.window_previous_state_ex| from string to this new type