### PR TITLE
Update overwolf.d.ts

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -5300,7 +5300,7 @@ declare namespace overwolf.settings {
   }
 
   interface GeneralExtensionSettings {
-    auto_launch_with_overwolf: boolean;
+    auto_launch_with_overwolf?: boolean;
   }
 
   interface GetHotKeyResult extends Result {


### PR DESCRIPTION
GeneralExtensionSettings - auto_launch_with_overwolf should be optional so that when we add new properties, we won't force setting itt