### PR TITLE
Remove export from owads and update documentation on how to use typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @overwolf/types
 
-Overwolf type definition files for autocompletion and documentation purposes.  
+Overwolf type definition files for autocompletion and documentation purposes.
 
 ## Install
 
@@ -10,24 +10,23 @@ This is the preferred method. Getting type declarations in TypeScript 2.0 and ab
 $ npm i --save-dev @overwolf/types
 ```
 
+> In some configurations with webpack, you will get an error like this:
+>
+> ```
+> This dependency was not found:
+>
+> * @overwolf/types in ./node_modules/cache-loader/dist/cjs.js??ref--12-0!./node_modules/ts-loader??ref--12-1!./node_modules/cache-loader/dist/cjs.js??> ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!
+> ```
+>
+> To install it, you can run:
+> ```
+> npm install --save @overwolf/types
+> ```
+
 ## Usage
 
-To use it in your Typescript project, you should include this line on the top of each file that use the types.
+To use it in your Typescript project, you should add it as a `type` in your tsconfig.json
 
-```
-import "@overwolf/types";
-```
-
-In some configurations with webpack, you will get an error like this:
-From vue-cli project:
-```
-This dependency was not found:
-
-* @overwolf/types in ./node_modules/cache-loader/dist/cjs.js??ref--12-0!./node_modules/ts-loader??ref--12-1!./node_modules/cache-loader/dist/cjs.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!
-
-To install it, you can run: npm install --save @overwolf/types
-```
-What works here is adding it as types to your tsconfig.json, **INSTEAD OF IMPPORTING IT**
 ```
 {
   "compilerOptions":{
@@ -41,4 +40,12 @@ What works here is adding it as types to your tsconfig.json, **INSTEAD OF IMPPOR
   }
   ...
 }
+```
+
+## Overwolf Adverts
+
+To use the `owads` typings, add a triple-slash directive to the files that need to use the typings:
+
+```
+/// <reference path="../node_modules/@overwolf/types/owads.d.ts" />
 ```

--- a/owads.d.ts
+++ b/owads.d.ts
@@ -1,5 +1,5 @@
-export declare type EventDispCallback = (data: any) => void;
-export declare class EventDispatcher {
+declare type EventDispCallback = (data: any) => void;
+declare class EventDispatcher {
     addEventListener(
       eventName: string,
       listener: EventDispCallback): boolean;
@@ -9,17 +9,17 @@ export declare class EventDispatcher {
     fireEvent(eventName: string, eventData: any): null | undefined;
 }
 
-export declare type OwAdOptionsSize = {
+declare type OwAdOptionsSize = {
   width: number;
   height: number;
 }
 
-export interface OwAdOptions {
+interface OwAdOptions {
   autoplay?: boolean;
   size?: OwAdOptionsSize | OwAdOptionsSize[];
 }
 
-export declare class OwAd {
+declare class OwAd {
   constructor(container: HTMLElement, options: OwAdOptions);
   get uid(): string | null;
   get version(): string;


### PR DESCRIPTION
I'm using Parcel to build my app and it's really problematic to get it to use the `owads.d.ts` in its current form, so I'm proposing the following changes that work in my setup:

* Remove the `export` keyword from `owads.d.ts`, this makes it consistent with `overwolf.d.ts` def file
* Update the documentation, telling the dev to change their tsconfig.json - this is better practice and avoids confusing newcomers by giving them 2 different ways to achieve the same thing
* Give instruction on how to use the `owads` definitions (by using a triple slash directive)

Ideally, the `owads` would somehow be included when you add the `@overwolf/types` to the `types` property in tsconfig.json (so we can avoid using a triple slash directive or importing), but I'm not sure how to achieve that.