### PR TITLE
Give GetInfoResults a generic

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -2375,8 +2375,8 @@ declare namespace overwolf.games.launchers {
 }
 
 declare namespace overwolf.games.launchers.events {
-  interface GetInfoResult extends Result {
-    res: any;
+  interface GetInfoResult<T = any> extends Result {
+    res: T;
   }
 
   interface SetRequiredFeaturesResult extends Result {
@@ -4787,8 +4787,8 @@ declare namespace overwolf.extensions.io {
 }
 
 declare namespace overwolf.extensions.current {
-  interface GetExtraObject extends Result {
-    object?: any;
+  interface GetExtraObject<T = any> extends Result {
+    object?: T;
   }
 
   /**


### PR DESCRIPTION
Gives GetInfoResult's a generic so we can resure this type with the correct response types.

Should not break any existing types as we are just add a generic with a default.