### PR TITLE
Make OpenStoreParams:uid optional

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -5533,7 +5533,7 @@ declare namespace overwolf.utils {
     /**
      * The target app id.
      */
-    uid: string;
+    uid?: string;
     /**
      * Store page to open.
      */


### PR DESCRIPTION
From the examples, uid is optional:

https://overwolf.github.io/docs/api/overwolf-utils
overwolf.utils.openStore({
   page:overwolf.utils.enums.eStorePage.SubscriptionPage
  })