### PR TITLE
Add thumbnail_path in HighlightsCapturedEvent

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -873,6 +873,7 @@ declare namespace overwolf.media.replays {
     media_path: string;
     media_path_encoded: string;
     thumbnail_url: string;
+    thumbnail_path: string;
     thumbnail_encoded_path: string;
     replay_video_start_time: number;
   }


### PR DESCRIPTION
Based on https://overwolf.github.io/docs/api/overwolf-media-replays#event-data-example, `thumbnail_path` is part of `HighlightsCapturedEvent`. The documentation is misleading because there are missing line-breaks in `media_url` and `thumbnail_url` example.

![image](https://user-images.githubusercontent.com/10058950/125595694-b8a97f4c-943e-4c0b-ad02-ca259558a617.png)
