### PR TITLE
Games events

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -2637,8 +2637,10 @@ declare namespace overwolf.games.launchers {
 }
 
 declare namespace overwolf.games.launchers.events {
-  interface GetInfoResult<T = any> extends Result {
-    res: T;
+  interface GetInfoResult<T = any> {
+    status: 'error' | 'success';
+    res?: T;
+    reason?: string;
   }
 
   interface SetRequiredFeaturesResult extends Result {

--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -2735,10 +2735,23 @@ declare namespace overwolf.games.events {
     reason: string;
   }
 
-  interface InfoUpdate2 { }
+  interface InfoUpdate2 {
+    live_client_data?: {
+      active_player?: string;
+      all_players?: string;
+      events?: string;
+      game_data?: string;
+      port?: number;
+    };
+    game_info?: {
+      matchStarted?: 'true' | 'false';
+      matchId?: string;
+    };
+    [key: string]: any;
+  }
 
   interface InfoUpdates2Event
-    <Feature = string, Info extends InfoUpdate2 = InfoUpdate2> {
+    <Feature = string, Info extends InfoUpdate2[Feature] = InfoUpdate2> {
     info: Info;
     feature: Feature;
   }


### PR DESCRIPTION
This pull request has two commits.

1) 
Access `overwolf.games.events.onInfoUpdates2` results `info` property was always an empty object. `[key: string]: any;` is a temporary solution until all possibilities are added. I added only [live_client_data](https://overwolf.github.io/docs/api/overwolf-games-events-lol#live_client_data) and [game_info](https://overwolf.github.io/docs/api/overwolf-games-events-lol#matchstate). Can you check if this is correct?

In addition, `extends InfoUpdate2[Feature]` gives you the correct type if you previously checked the `Feature` (see screenshots).

![image](https://user-images.githubusercontent.com/10058950/125627213-10721182-8f16-416e-970f-ff3d745f171c.png)

![image](https://user-images.githubusercontent.com/10058950/125627222-8a0e65b5-c28e-4ee9-b63b-391ce7a22bf8.png)

2)

Calling `overwolf.games.launchers.events.getInfo(10902, console.log)` (when League Launcher is running)  returns and object with `success`, `status` and `res`.
Calling the same method with an unknown ID like  `overwolf.games.launchers.events.getInfo(999999, console.log)`  returns an object with `success`, `status` and `reason`.
There is not `error` property, even if TypeScript tells me so. 
Thus, I removed `extends Result` to remove `error` from the result and added `status` and `reason`. `res` is optional.
