### PR TITLE
Fix optional fields in MemoryScreenshotParams

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -315,9 +315,9 @@ declare namespace  overwolf.media {
   }
 
   interface MemoryScreenshotParams {
-    roundAwayFromZero: boolean;
-    rescale: RescaleParams;
-    crop: CropParams;
+    roundAwayFromZero?: boolean;
+    rescale?: RescaleParams;
+    crop?: CropParams;
   }
 
   interface FileResult extends Result {


### PR DESCRIPTION
These fields are optional. See https://overwolf.github.io/docs/api/overwolf-media#usage-example