### PR TITLE
Fix a documentation issue with GameInfoUpdatedEvent reason

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -2604,7 +2604,7 @@ declare namespace overwolf.games {
     gameChanged: boolean;
     gameOverlayChanged: boolean;
     overlayInputHookError?: boolean;
-    reason?: GameInfoChangeReason;
+    reason: ReadonlyArray<GameInfoChangeReason>;
   }
 
   interface MajorFrameRateChangeEvent {


### PR DESCRIPTION
`GameInfoUpdatedEvent` is documented to have reason field which is typed as `GameInfoChangeReason` but what I am getting when listening to this event is actually an array with one element
![image](https://user-images.githubusercontent.com/15785773/138763777-78bed80a-1663-4919-92f2-b1d000d45803.png)
