### PR TITLE
Update getLastRunningGameInfo callback result type

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -2616,6 +2616,8 @@ declare namespace overwolf.games {
     gameInfo: GetRunningGameInfoResult2GameInfo | null
   }
 
+  interface GetLastRunningGameInfoResult extends GetRunningGameInfoResult2 {}
+
   interface OverlayInfo {
     coexistingApps?: KnownOverlayCoexistenceApps[];
     inputFailure?: boolean;
@@ -2707,7 +2709,7 @@ declare namespace overwolf.games {
    * @param callback Called with the result.
    */
   function getLastRunningGameInfo(
-    callback: CallbackFunction<GetGameInfoResult>
+    callback: CallbackFunction<GetLastRunningGameInfoResult>
   ): void;
 
   /**


### PR DESCRIPTION
`getLastRunningGameInfo`'s callback result has the same type as `GetRunningGameInfoResult2` not `GetGameInfoResult`

console output on Overwolf version 0.191.0.19 (Developers).
![image](https://user-images.githubusercontent.com/8888281/155437697-ccb6ea61-a88d-4390-9704-75cbcecb45d5.png)
