### PR TITLE
Fix nullable data in DirResult

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -111,7 +111,7 @@ declare namespace overwolf.io {
   }
 
   interface DirResult extends Result {
-    data?: FileInDir[];
+    data: FileInDir[] | null;
   }
 
   interface FileInDir {


### PR DESCRIPTION
Hi, calling `overwolf.io.dir` with an unknown path results in `null` for `data`.

The docs are not mention this too.
https://overwolf.github.io/api/io#dirresult-object