### PR TITLE
Add dpiScale to WindowInfo object

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -1308,6 +1308,7 @@ declare namespace overwolf.windows {
 
   interface WindowInfo {
     name: string;
+    dpiScale: number;
     id: string;
     state: string;
     stateEx: enums.WindowStateEx;


### PR DESCRIPTION
Calling `overwolf.windows.getCurrentWindow` returns `dpiScale` which is updated based on current scaling.

Example:
```json
{
  "window": {
    "id": "Window_Extension_lbkdbgdijedpnmifplbkcjgbioaklmpghbehfmnp_desktop",
    "name": "desktop",
    "width": 400,
    "height": 660,
    "top": 200,
    "left": 3040,
    "isVisible": true,
    "logicalBounds": {
      "top": 200,
      "left": 3040,
      "width": 400,
      "height": 660
    },
    "state": "Normal",
    "dpiScale": 1,
    "stateEx": "normal",
    "monitorId": "\\\\.\\DISPLAY1",
    "type": "Desktop"
  },
  "status": "success",
  "success": true
}
```

Related to https://github.com/overwolf/overwolf.github.io/pull/1018