### PR TITLE
Adds a "void" return type to uploadVideo and cancelUpload

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -6485,9 +6485,9 @@ declare namespace overwolf.social {
    */
   function getDisabledServices(callback: CallbackFunction<GetDisabledServicesResult<void>>): void;
 
-  function uploadVideo(uploadParams: VideoUploadParams, resultCallback: CallbackFunction<VideoUploadResult>, progressCallback: CallbackFunction<VideoUploadProgress>)
+  function uploadVideo(uploadParams: VideoUploadParams, resultCallback: CallbackFunction<VideoUploadResult>, progressCallback: CallbackFunction<VideoUploadProgress>): void;
 
-  function cancelUpload(id: string, resultCallback: CallbackFunction<Result>)
+  function cancelUpload(id: string, resultCallback: CallbackFunction<Result>): void;
 }
 
 declare namespace overwolf.social.discord {


### PR DESCRIPTION
`uploadVideo` and `cancelUpload` lack return types, so running `tsc` with the `noImplicitAny` flag set to `true` will fail to compile.

This PR sets the return type to `void` since the value/error is returned via the callback.