### PR TITLE
CheckForUpdateResult should be string or null, not undefined

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -5149,7 +5149,7 @@ declare namespace overwolf.extensions {
 
   interface CheckForUpdateResult extends Result {
     state?: "UpToDate" | "UpdateAvailable" | "PendingRestart"; //should be changed in the future to the enum "ExtensionUpdateState"
-    updateVersion?: string;
+    updateVersion: string | null;
   }
 
   interface ServiceProvidersDataResult extends Result {


### PR DESCRIPTION
According to the docs, `updateVersion` can either be `string` or `null` (not `undefined`)
https://overwolf.github.io/api/extensions#checkforupdateresult-object