### PR TITLE
Added string literals to enum WatchEventType

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -63,10 +63,10 @@ declare namespace overwolf.io {
     }
 
     const enum WatchEventType {
-      Registered,
-      Changed,
-      Renamed,
-      Deleted
+      Registered = "Registered",
+      Changed = "Changged",
+      Renamed = "Renamed",
+      Deleted = "Deleted"
     }
   }
 


### PR DESCRIPTION
When using typescript, calling overwolf.io.enums.WatchEventType.Changed is returning 1 instead of 'Changed'