### PR TITLE
Changed the result type of readBinaryFile to contain an array buffer and optional length

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -129,7 +129,7 @@ declare namespace overwolf.io {
 
   interface ReadBinaryFileResult extends Result {
     content?: string;
-    info?: FileInfo;
+    length?: number;
   }
 
   interface ReadTextFileResult extends Result {

--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -128,7 +128,7 @@ declare namespace overwolf.io {
   }
 
   interface ReadBinaryFileResult extends Result {
-    content?: string;
+    content?: ArrayBuffer;
     length?: number;
   }
 


### PR DESCRIPTION
I'm not sure if this is a bug or an outdated type definition, but seems like `readBinaryFile` does not return an optional `info` object - it only returns an optional `length`.

Also, `content?` is not a `string`, but an `ArrayBuffer`

I checked `readTextFile` and it seems to properly return the optional `info` object and a `string` for `content` - seems like it might be some copy-paste error.