### PR TITLE
Fix getRunningGameInfo can return null

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -2601,7 +2601,7 @@ declare namespace overwolf.games {
    * @param callback Called with the currently running or active game info. See
    */
   function getRunningGameInfo(
-    callback: CallbackFunction<GetRunningGameInfoResult>
+    callback: CallbackFunction<GetRunningGameInfoResult | null>
   ): void;
 
   /**


### PR DESCRIPTION
I know that this function is obsolete ;), but it might be better to have the correct return type.