### PR TITLE
Allow null for GameInfoUpdatedEvent's gameInfo

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -2576,7 +2576,7 @@ declare namespace overwolf.games {
   }
 
   interface GameInfoUpdatedEvent {
-    gameInfo?: RunningGameInfo;
+    gameInfo?: RunningGameInfo | null;
     resolutionChanged: boolean;
     runningChanged: boolean;
     focusChanged: boolean;


### PR DESCRIPTION
Discord discussion: https://discord.com/channels/501313732480204808/1269026972302966795/1269026972302966795

EdoMathiasQA: 
> Handled the pull request about the webpack,
> 
> The reason we send the gameChanged as well after gameTerminated is because of backwards compatibility.
> 
> Before we've added the gameTerminated event we always sent gameChanged

> Since gameChanged tries to account for a new game, gameInfo returns as null because you didn't really change to a different game, you closed it. 