### PR TITLE
Changed the properties of ReadFileOptions to optional

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -95,9 +95,9 @@ declare namespace overwolf.io {
   }
 
   interface ReadFileOptions {
-    encoding: enums.eEncoding;
-    maxBytesToRead: number;
-    offset: number;
+    encoding?: enums.eEncoding;
+    maxBytesToRead?: number;
+    offset?: number;
   }
 
   interface ListenFileOptions {


### PR DESCRIPTION
I'm using `overwolf.io.readBinaryFile` and sending `{}` as options and everything is working fine, thought to update the types to reflect it.