### PR TITLE
feat(notifications): add launch + activationType to ToastNotification…

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -1058,6 +1058,8 @@ declare namespace overwolf.notifications {
      * Buttons make your toast interactive, letting the user take quick actions on your toast notification without interrupting their current workflow. Buttons appear in the expanded portion of your notification.
      */
     buttons?: ToastNotificationButton[];
+    launch?: string;
+    activationType?: 'protocol' | 'foreground' | 'background';
   }
 
   interface LogoOverride {
@@ -1068,6 +1070,8 @@ declare namespace overwolf.notifications {
   interface ToastNotificationButton {
     id: string;
     text: string;
+    launch?: string;
+    activationType?: 'protocol' | 'foreground' | 'background';
   }
 
   interface ShowToastNotificationResult extends Result {


### PR DESCRIPTION
…Params and ToastNotificationButton

The Overwolf runtime already supports embedding a `launch` URI and `activationType` in the underlying toast XML (matching the Windows toast schema), but the TypeScript types did not expose these fields.

`launch` (string URI) + `activationType` ('protocol'|'foreground'|'background') are added as optional fields on both `ToastNotificationParams` and `ToastNotificationButton`.

With `activationType: 'protocol'` and a URI matching the app's registered scheme, the OS invokes the URI via
`overwolf.extensions.onAppLaunchTriggered` (origin: 'urlscheme') when the user clicks the toast — including from the Windows notification center (Action Center) and on a cold start, which the in-process `onToastInteraction` event cannot reach.

Motivated by OW-6562 / CF-10763.